### PR TITLE
refactor: StatusFormDialog and ToDoFormDialog use context instead of props

### DIFF
--- a/src/StatusFormDialog.js
+++ b/src/StatusFormDialog.js
@@ -10,12 +10,13 @@ import {
   TextField,
 } from "@mui/material";
 
-const StatusFormDialog = ({ isOpen, setIsOpen }) => {
-  const { addToStatusList } = useContext(ToDoContext);
+const StatusFormDialog = () => {
+  const { addToStatusList, setIsStatusFormDialogOpen, isStatusFormDialogOpen } =
+    useContext(ToDoContext);
   const [newStatus, setNewStatus] = useState("");
 
   const handleClose = () => {
-    setIsOpen(false);
+    setIsStatusFormDialogOpen(false);
   };
 
   const handleInputChange = (event) => {
@@ -25,12 +26,12 @@ const StatusFormDialog = ({ isOpen, setIsOpen }) => {
 
   const handleSubmit = () => {
     addToStatusList(newStatus);
-    setIsOpen(false);
+    setIsStatusFormDialogOpen(false);
     setNewStatus("");
   };
 
   return (
-    <Dialog open={isOpen} onClose={handleClose}>
+    <Dialog open={isStatusFormDialogOpen} onClose={handleClose}>
       <DialogTitle>New Status:</DialogTitle>
       <Box
         component="form"

--- a/src/ToDoContext.js
+++ b/src/ToDoContext.js
@@ -50,17 +50,19 @@ export const ToDoProvider = ({ children }) => {
   };
 
   const providerValue = {
-    defaultNewToDo,
+    toDoList,
+    statusList,
+    isToDoFormDialogOpen,
+    setIsToDoFormDialogOpen,
     isToDoFormNew,
     setIsToDoFormNew,
+    defaultNewToDo,
     toDoFormData,
     setToDoFormData,
-    toDoList,
-    setIsToDoFormDialogOpen,
-    isToDoFormDialogOpen,
-    statusList,
-    addToStatusList,
+    isStatusFormDialogOpen,
+    setIsStatusFormDialogOpen,
     createToDo,
+    addToStatusList,
     updateToDo,
     deleteToDo,
   };
@@ -68,15 +70,8 @@ export const ToDoProvider = ({ children }) => {
   return (
     <ToDoContext.Provider value={providerValue}>
       {children}
-      <ToDoFormDialog
-        isOpen={isToDoFormDialogOpen}
-        setIsOpen={setIsToDoFormDialogOpen}
-        isToDoFormNew={isToDoFormNew}
-      />
-      <StatusFormDialog
-        isOpen={isStatusFormDialogOpen}
-        setIsOpen={setIsStatusFormDialogOpen}
-      />
+      <ToDoFormDialog />
+      <StatusFormDialog />
     </ToDoContext.Provider>
   );
 };

--- a/src/ToDoFormDialog.js
+++ b/src/ToDoFormDialog.js
@@ -16,7 +16,7 @@ import {
 } from "@mui/material";
 import { DatePicker } from "@mui/x-date-pickers";
 
-const ToDoForm = ({ isOpen, setIsOpen }) => {
+const ToDoForm = () => {
   const {
     createToDo,
     isToDoFormNew,
@@ -25,6 +25,8 @@ const ToDoForm = ({ isOpen, setIsOpen }) => {
     updateToDo,
     toDoFormData,
     setToDoFormData,
+    isToDoFormDialogOpen,
+    setIsToDoFormDialogOpen,
   } = useContext(ToDoContext);
 
   const toDoFormTitle = (isToDoFormNew) => {
@@ -34,7 +36,7 @@ const ToDoForm = ({ isOpen, setIsOpen }) => {
   const [showWarning, setShowWarning] = useState(false);
 
   const handleClose = () => {
-    setIsOpen(false);
+    setIsToDoFormDialogOpen(false);
     setToDoFormData(defaultNewToDo);
     setShowWarning(false);
   };
@@ -57,7 +59,7 @@ const ToDoForm = ({ isOpen, setIsOpen }) => {
       } else {
         updateToDo(toDoFormData);
       }
-      setIsOpen(false);
+      setIsToDoFormDialogOpen(false);
       setToDoFormData(defaultNewToDo);
       setShowWarning(false);
     } else {
@@ -66,7 +68,7 @@ const ToDoForm = ({ isOpen, setIsOpen }) => {
   };
 
   return (
-    <Dialog open={isOpen} onClose={handleClose}>
+    <Dialog open={isToDoFormDialogOpen} onClose={handleClose}>
       <DialogTitle>{toDoFormTitle(isToDoFormNew)}</DialogTitle>
       <Box
         component="form"


### PR DESCRIPTION
- Refactored StatusFormDialog to use isStatusFormDialogOpen from context instead of isOpen prop
- Refactored ToDoFormDialog to use isToDoFormDialogOpen  from context instead of isOpen prop