### PR TITLE
feat(AppSettings): Add support for system dark mode preference

### DIFF
--- a/src/contexts/AppSettingsContext.jsx
+++ b/src/contexts/AppSettingsContext.jsx
@@ -4,7 +4,10 @@ const AppSettingsContext = createContext();
 export default AppSettingsContext;
 
 export const AppSettingsProvider = ({ children }) => {
-  const [isDarkMode, setIsDarkMode] = useState(false);
+  const isPrefersDark = window.matchMedia(
+    "(prefers-color-scheme: dark)"
+  ).matches;
+  const [isDarkMode, setIsDarkMode] = useState(isPrefersDark);
   const toggleDarkMode = () => setIsDarkMode((prev) => !prev);
 
   const providerValue = {


### PR DESCRIPTION
- Added `isPrefersDark` variable to check if the user prefers dark mode based on their system settings
- Set initial value of `isDarkMode` state to `isPrefersDark`

This commit adds support for detecting and using the system's dark mode preference when initializing the app's dark mode setting.