### PR TITLE
Fix/hooks/refresh token

### DIFF
--- a/.env
+++ b/.env
@@ -1,8 +1,8 @@
 
 ## local
-# REACT_APP_API_URL=https://localhost:3000
+REACT_APP_API_URL=http://localhost:3000
 
 ## deployed
-REACT_APP_API_URL=https://159.89.32.135:3000
+# REACT_APP_API_URL=https://159.89.32.135:3000
 
 PORT=1337

--- a/src/hooks/role.js
+++ b/src/hooks/role.js
@@ -9,7 +9,7 @@ export const useGetRoleList = () => {
   return useQuery({
     queryKey: ["roleList"],
     queryFn: async () => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestGetRoleList({ accessToken });
     },
     onError: (error) => {

--- a/src/hooks/status.js
+++ b/src/hooks/status.js
@@ -16,7 +16,7 @@ export const useGetStatusList = () => {
   return useQuery({
     queryKey: ["statusList"],
     queryFn: async () => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestGetStatusList({ accessToken });
     },
     onError: (error) => {
@@ -33,7 +33,7 @@ export const useCreateStatus = () => {
 
   return useMutation({
     mutationFn: async (status) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestCreateStatus({ accessToken, status });
     },
     onMutate: async (newStatus) => {
@@ -63,7 +63,7 @@ export const useRemoveStatus = () => {
 
   return useMutation({
     mutationFn: async (id) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestRemoveStatus({ accessToken, id });
     },
     onMutate: async (id) => {
@@ -94,7 +94,7 @@ export const useUpdateStatus = () => {
 
   return useMutation({
     mutationFn: async (status) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestUpdateStatus({ accessToken, status });
     },
     onMutate: async (updatedStatus) => {
@@ -131,7 +131,7 @@ export const useUpdateStatusList = () => {
 
   return useMutation({
     mutationFn: async (statusList) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestUpdateStatusList({ accessToken, statusList });
     },
     onMutate: async (updatedStatusList) => {

--- a/src/hooks/toDo.js
+++ b/src/hooks/toDo.js
@@ -16,7 +16,7 @@ export const useGetToDoList = () => {
   return useQuery({
     queryKey: ["toDoList"],
     queryFn: async () => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestGetToDoList({ accessToken });
     },
     onError: (error) => {
@@ -33,7 +33,7 @@ export const useCreateToDo = () => {
 
   return useMutation({
     mutationFn: async (toDo) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestCreateToDo({ accessToken, toDo });
     },
     onMutate: async (toDo) => {
@@ -63,7 +63,7 @@ export const useRemoveToDo = () => {
 
   return useMutation({
     mutationFn: async (id) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestRemoveToDo({ accessToken, id });
     },
     onMutate: async (id) => {
@@ -94,7 +94,7 @@ export const useUpdateToDo = () => {
 
   return useMutation({
     mutationFn: async (toDo) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestUpdateToDo({ accessToken, toDo });
     },
     onMutate: async (updatedToDo) => {
@@ -129,7 +129,7 @@ export const useUpdateToDoList = () => {
 
   return useMutation({
     mutationFn: async (toDoList) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestUpdateToDoList({ accessToken, toDoList });
     },
     onMutate: async (updatedToDoList) => {

--- a/src/hooks/user.js
+++ b/src/hooks/user.js
@@ -14,7 +14,7 @@ export const useGetUserList = () => {
   return useQuery({
     queryKey: ["userList"],
     queryFn: async () => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestGetUserList({ accessToken });
     },
     onError: (error) => {
@@ -31,7 +31,7 @@ export const useGetOneUser = (id) => {
   return useQuery({
     queryKey: ["user", id],
     queryFn: async () => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestGetOneUser({ id, accessToken });
     },
     onError: (error) => {
@@ -48,7 +48,7 @@ export const useUpdateUser = () => {
 
   return useMutation({
     mutationFn: async ({ userId, body }) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestUpdateUser({
         userId,
         accessToken,
@@ -88,7 +88,7 @@ export const useUpdateUserRoles = () => {
 
   return useMutation({
     mutationFn: async ({ userId, roles }) => {
-      const accessToken = await getAccessTokenSilently();
+      const accessToken = await getAccessTokenSilently({ cacheMode: "off" });
       return requestUpdateUserRoles({ accessToken, roles, userId });
     },
     onMutate: async (updatedUser) => {


### PR DESCRIPTION
After reviewing [the documentation for the getAccessTokenSilently method](https://auth0.github.io/auth0-react/interfaces/GetTokenSilentlyOptions.html) I found that by default it caches the token and if we pass the `cacheMode: off` option, that solves our issue of using a stale token to make requests to our server after the default roles have been given to the new user.

Also i changed the `API_URL` in .env file to use http instead of https for localhost